### PR TITLE
Fix: Use typeResolvers to resolve field arguments as well

### DIFF
--- a/src/Resolver/Type/FieldResolver.php
+++ b/src/Resolver/Type/FieldResolver.php
@@ -184,7 +184,9 @@ final readonly class FieldResolver
                 }
 
                 if ($argumentNode instanceof ArgNode) {
-                    $arguments[] = $args[$argumentNode->name] ?? null;
+                    $arguments[] = $typeResolverSelector
+                        ->getResolver($argumentNode->reference)
+                        ->abstract($argumentNode, $args);
 
                     continue;
                 }

--- a/tests/Doubles/FullFeatured/Type/FoobarType.php
+++ b/tests/Doubles/FullFeatured/Type/FoobarType.php
@@ -38,7 +38,7 @@ final readonly class FoobarType
     }
 
     #[Field(type: new NullableType(new ConnectionType(AgentType::class)))]
-    public function getUsers(EdgeArgs $edgeArgs, ?string $status): Connection
+    public function getUsers(EdgeArgs $edgeArgs, ?FoobarStatusType $status): Connection
     {
         return new Connection([]);
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -620,7 +620,7 @@ final class ParserTest extends TestCase
                         [
                             new EdgeArgsNode('edgeArgs'),
                             new ArgNode(
-                                ScalarTypeReference::create('string')->setNullableValue(),
+                                ObjectTypeReference::create(FoobarStatusType::class)->setNullableValue(),
                                 'status',
                                 null,
                                 'status',

--- a/tests/SchemaBuilderTest.php
+++ b/tests/SchemaBuilderTest.php
@@ -817,7 +817,21 @@ final class SchemaBuilderTest extends TestCase
                                     'args' => [
                                         [
                                             'name' => 'status',
-                                            'type' => Type::string(),
+                                            'type' =>  new EnumType([
+                                                'name' => 'FoobarStatus',
+                                                'description' => 'Foobar status',
+                                                'values' => [
+                                                    'open' => [
+                                                        'value' => 'open',
+                                                        'description' => null,
+                                                    ],
+                                                    'closed' => [
+                                                        'value' => 'closed',
+                                                        'description' => 'Foobar status Closed',
+                                                        'deprecationReason' => 'Its deprecated',
+                                                    ],
+                                                ],
+                                            ]),
                                             'description' => null,
                                         ],
                                         [
@@ -1315,7 +1329,21 @@ final class SchemaBuilderTest extends TestCase
                             'args' => [
                                 [
                                     'name' => 'status',
-                                    'type' => Type::string(),
+                                    'type' => new EnumType([
+                                        'name' => 'FoobarStatus',
+                                        'description' => 'Foobar status',
+                                        'values' => [
+                                            'open' => [
+                                                'value' => 'open',
+                                                'description' => null,
+                                            ],
+                                            'closed' => [
+                                                'value' => 'closed',
+                                                'description' => 'Foobar status Closed',
+                                                'deprecationReason' => 'Its deprecated',
+                                            ],
+                                        ],
+                                    ]),
                                     'description' => null,
                                 ],
                                 [


### PR DESCRIPTION
# Description
Use typeResolvers to resolve field arguments as well. Just as with arguments on root level (query, mutation) (RootTypeResolver), arguments for a field should also be resolved by the typeResolvers.

E.g. in this way, an enum gets resolved to the Enum class instead of a string:

```php
#[Type]
final readonly class SomeType
{
    #[Field]
    public function someField(SomeEnum $enum) : SomeType
    {
        // $enum should be of type SomeEnum, not string
    }
}
```