### PR TITLE
[Fix] Enable interface Types on field level (as well)

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -326,6 +326,24 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Resolver/Type/UnionTypeResolver.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Method Jerowork\\\\GraphqlAttributeSchema\\\\SchemaBuilder\\:\\:getTypesImplementingInterface\\(\\) return type has no value type specified in iterable type iterable\\<mixed\\>\\.$#',
+	'identifier' => 'missingType.iterableValue',
+	'count' => 1,
+	'path' => __DIR__ . '/src/SchemaBuilder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^PHPDoc tag @return contains unresolvable type\\.$#',
+	'identifier' => 'return.unresolvableType',
+	'count' => 1,
+	'path' => __DIR__ . '/src/SchemaBuilder.php',
+];
+$ignoreErrors[] = [
+	'message' => '#^Parameter \\#1 \\$config of class GraphQL\\\\Type\\\\Schema constructor expects array\\{query\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, mutation\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, subscription\\?\\: \\(callable\\(\\)\\: \\(GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null\\)\\)\\|GraphQL\\\\Type\\\\Definition\\\\ObjectType\\|null, types\\?\\: \\(callable\\(\\)\\: iterable\\<callable\\(\\)\\: GraphQL\\\\Type\\\\Definition\\\\Type&GraphQL\\\\Type\\\\Definition\\\\NamedType\\>\\)\\|\\(callable\\(\\)\\: iterable\\<GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\>\\)\\|iterable\\<\\(callable\\(\\)\\: GraphQL\\\\Type\\\\Definition\\\\Type&GraphQL\\\\Type\\\\Definition\\\\NamedType\\)\\|\\(GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\)\\>\\|null, directives\\?\\: array\\<GraphQL\\\\Type\\\\Definition\\\\Directive\\>\\|null, typeLoader\\?\\: \\(callable\\(string\\)\\: \\(\\(GraphQL\\\\Type\\\\Definition\\\\NamedType&GraphQL\\\\Type\\\\Definition\\\\Type\\)\\|null\\)\\)\\|null, assumeValid\\?\\: bool\\|null, astNode\\?\\: GraphQL\\\\Language\\\\AST\\\\SchemaDefinitionNode\\|null, \\.\\.\\.\\}\\|GraphQL\\\\Type\\\\SchemaConfig, array\\{query\\: GraphQL\\\\Type\\\\Definition\\\\ObjectType, mutation\\: GraphQL\\\\Type\\\\Definition\\\\ObjectType, types\\: iterable\\<mixed\\>\\} given\\.$#',
+	'identifier' => 'argument.type',
+	'count' => 1,
+	'path' => __DIR__ . '/src/SchemaBuilder.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Method Jerowork\\\\GraphqlAttributeSchema\\\\Util\\\\Reflector\\\\Reflector\\:\\:getClasses\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#',
 	'identifier' => 'missingType.generics',
 	'count' => 1,

--- a/src/Ast.php
+++ b/src/Ast.php
@@ -6,7 +6,9 @@ namespace Jerowork\GraphqlAttributeSchema;
 
 use Jerowork\GraphqlAttributeSchema\Node\AliasedNode;
 use Jerowork\GraphqlAttributeSchema\Node\ArraySerializable;
+use Jerowork\GraphqlAttributeSchema\Node\InterfaceTypeNode;
 use Jerowork\GraphqlAttributeSchema\Node\Node;
+use Jerowork\GraphqlAttributeSchema\Node\TypeNode;
 
 /**
  * @phpstan-type AstPayload array{
@@ -67,6 +69,28 @@ final readonly class Ast implements ArraySerializable
         }
 
         return null;
+    }
+
+    /**
+     * @return list<TypeNode|InterfaceTypeNode>
+     */
+    public function getNodesImplementingInterface(): array
+    {
+        $nodes = [];
+
+        foreach ($this->nodes as $node) {
+            if (!$node instanceof InterfaceTypeNode && !$node instanceof TypeNode) {
+                continue;
+            }
+
+            if ($node->implementsInterfaces === []) {
+                continue;
+            }
+
+            $nodes[] = $node;
+        }
+
+        return $nodes;
     }
 
     /**

--- a/src/Resolver/Type/InterfaceTypeResolver.php
+++ b/src/Resolver/Type/InterfaceTypeResolver.php
@@ -58,7 +58,7 @@ final class InterfaceTypeResolver implements TypeResolver
     #[Override]
     public function resolve(TypeReference $reference, Closure $callback): mixed
     {
-        throw new LogicException('InterfaceType does not need to resolve');
+        return $callback();
     }
 
     #[Override]

--- a/src/SchemaBuilder.php
+++ b/src/SchemaBuilder.php
@@ -4,16 +4,24 @@ declare(strict_types=1);
 
 namespace Jerowork\GraphqlAttributeSchema;
 
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use Jerowork\GraphqlAttributeSchema\Node\MutationNode;
 use Jerowork\GraphqlAttributeSchema\Node\QueryNode;
+use Jerowork\GraphqlAttributeSchema\Node\TypeReference\ObjectTypeReference;
+use Jerowork\GraphqlAttributeSchema\Resolver\BuiltTypesRegistry;
 use Jerowork\GraphqlAttributeSchema\Resolver\RootTypeResolver;
+use Jerowork\GraphqlAttributeSchema\Resolver\Type\TypeResolverSelector;
 
 final readonly class SchemaBuilder
 {
     public function __construct(
         private AstContainer $astContainer,
+        private BuiltTypesRegistry $builtTypesRegistry,
+        private TypeResolverSelector $typeResolverSelector,
         private RootTypeResolver $rootTypeResolver,
     ) {}
 
@@ -45,6 +53,43 @@ final readonly class SchemaBuilder
                 'name' => 'Mutation',
                 'fields' => $mutations,
             ]),
+            'types' => $this->getTypesImplementingInterface(),
         ]);
+    }
+
+    /**
+     * Get all types implementing an interface.
+     * When an implementation is not defined in a schema, it's not automatically loaded by the resolvers.
+     * Therefore, load all interface implementation types on the root schema level as well.
+     *
+     * @return iterable<Closure(): Type>
+     */
+    private function getTypesImplementingInterface(): iterable
+    {
+        foreach ($this->astContainer->getAst()->getNodesImplementingInterface() as $node) {
+            $typeReference = ObjectTypeReference::create($node->getClassName());
+
+            if ($this->builtTypesRegistry->hasType($node->getClassName())) {
+                continue;
+            }
+
+            $type = $this->typeResolverSelector->getResolver($typeReference)->createType($typeReference);
+
+            if ($type instanceof NonNull) {
+                $type = $type->getWrappedType();
+            }
+
+            if ($type instanceof ListOfType) {
+                $type = $type->getWrappedType();
+
+                if ($type instanceof NonNull) {
+                    $type = $type->getWrappedType();
+                }
+            }
+
+            $this->builtTypesRegistry->addType($node->getClassName(), $type);
+
+            yield fn() => $type;
+        }
     }
 }

--- a/src/SchemaBuilderFactory.php
+++ b/src/SchemaBuilderFactory.php
@@ -80,6 +80,8 @@ final readonly class SchemaBuilderFactory
 
         return new SchemaBuilder(
             $astContainer,
+            $builtTypesRegistry,
+            $typeResolverSelector,
             new RootTypeResolver(
                 $typeResolverSelector,
                 $container,

--- a/src/SchemaBuilderFactory.php
+++ b/src/SchemaBuilderFactory.php
@@ -34,53 +34,54 @@ final readonly class SchemaBuilderFactory
         $deferredTypeResolver = new DeferredTypeResolver($container, new DeferredTypeRegistryFactory());
 
         $fieldResolver = new FieldResolver($container, $deferredTypeResolver);
+        $typeResolverSelector = new TypeResolverSelector([
+            new ListAndNullableTypeResolverDecorator(
+                new BuiltInScalarTypeResolver(),
+            ),
+            new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
+                $astContainer,
+                new CustomScalarTypeResolver($astContainer),
+                $builtTypesRegistry,
+            )),
+            new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
+                $astContainer,
+                new EnumTypeResolver($astContainer),
+                $builtTypesRegistry,
+            )),
+            new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
+                $astContainer,
+                new InputObjectTypeResolver($astContainer, $fieldResolver),
+                $builtTypesRegistry,
+            )),
+            new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
+                $astContainer,
+                new ObjectTypeResolver($astContainer, $fieldResolver),
+                $builtTypesRegistry,
+            )),
+            new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
+                $astContainer,
+                new InterfaceTypeResolver($astContainer, $builtTypesRegistry, $fieldResolver),
+                $builtTypesRegistry,
+            )),
+            new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
+                $astContainer,
+                new UnionTypeResolver($builtTypesRegistry),
+                $builtTypesRegistry,
+            )),
+            new ListAndNullableTypeResolverDecorator(
+                new ConnectionTypeResolver(
+                    $astContainer,
+                    $builtTypesRegistry,
+                    new PageInfoTypeResolver($builtTypesRegistry),
+                    new EdgeTypeResolver($astContainer, $builtTypesRegistry, $fieldResolver),
+                ),
+            ),
+        ]);
 
         return new SchemaBuilder(
             $astContainer,
             new RootTypeResolver(
-                new TypeResolverSelector([
-                    new ListAndNullableTypeResolverDecorator(
-                        new BuiltInScalarTypeResolver(),
-                    ),
-                    new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
-                        $astContainer,
-                        new CustomScalarTypeResolver($astContainer),
-                        $builtTypesRegistry,
-                    )),
-                    new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
-                        $astContainer,
-                        new EnumTypeResolver($astContainer),
-                        $builtTypesRegistry,
-                    )),
-                    new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
-                        $astContainer,
-                        new InputObjectTypeResolver($astContainer, $fieldResolver),
-                        $builtTypesRegistry,
-                    )),
-                    new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
-                        $astContainer,
-                        new ObjectTypeResolver($astContainer, $fieldResolver),
-                        $builtTypesRegistry,
-                    )),
-                    new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
-                        $astContainer,
-                        new InterfaceTypeResolver($astContainer, $builtTypesRegistry, $fieldResolver),
-                        $builtTypesRegistry,
-                    )),
-                    new ListAndNullableTypeResolverDecorator(new BuiltTypesRegistryTypeResolverDecorator(
-                        $astContainer,
-                        new UnionTypeResolver($builtTypesRegistry),
-                        $builtTypesRegistry,
-                    )),
-                    new ListAndNullableTypeResolverDecorator(
-                        new ConnectionTypeResolver(
-                            $astContainer,
-                            $builtTypesRegistry,
-                            new PageInfoTypeResolver($builtTypesRegistry),
-                            new EdgeTypeResolver($astContainer, $builtTypesRegistry, $fieldResolver),
-                        ),
-                    ),
-                ]),
+                $typeResolverSelector,
                 $container,
                 $fieldResolver,
                 $deferredTypeResolver,

--- a/tests/AstTest.php
+++ b/tests/AstTest.php
@@ -9,6 +9,7 @@ use Jerowork\GraphqlAttributeSchema\Node\Child\ArgNode;
 use Jerowork\GraphqlAttributeSchema\Node\Child\EnumValueNode;
 use Jerowork\GraphqlAttributeSchema\Node\EnumNode;
 use Jerowork\GraphqlAttributeSchema\Node\InputTypeNode;
+use Jerowork\GraphqlAttributeSchema\Node\InterfaceTypeNode;
 use Jerowork\GraphqlAttributeSchema\Node\MutationNode;
 use Jerowork\GraphqlAttributeSchema\Node\QueryNode;
 use Jerowork\GraphqlAttributeSchema\Node\TypeNode;
@@ -17,6 +18,8 @@ use Jerowork\GraphqlAttributeSchema\Node\TypeReference\ScalarTypeReference;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Enum\TestAnotherEnumType;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Enum\TestEnumType;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\InputType\TestInputType;
+use Jerowork\GraphqlAttributeSchema\Test\Doubles\InterfaceType\TestInterfaceType;
+use Jerowork\GraphqlAttributeSchema\Test\Doubles\InterfaceType\TestOtherInterfaceType;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Mutation\TestMutation;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Query\TestQuery;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Type\Loader\TestTypeLoader;
@@ -34,6 +37,7 @@ final class AstTest extends TestCase
     private EnumNode $enumNode1;
     private EnumNode $enumNode2;
     private TypeNode $typeNode;
+    private InterfaceTypeNode $interfaceTypeNode;
 
     #[Override]
     protected function setUp(): void
@@ -56,7 +60,9 @@ final class AstTest extends TestCase
                 null,
                 [],
                 null,
-                [],
+                [
+                    TestInterfaceType::class,
+                ],
             ),
             $this->enumNode2 =new EnumNode(
                 TestAnotherEnumType::class,
@@ -73,6 +79,16 @@ final class AstTest extends TestCase
                 null,
                 [],
             ),
+            $this->interfaceTypeNode = new InterfaceTypeNode(
+                TestInterfaceType::class,
+                'test',
+                null,
+                [],
+                null,
+                [
+                    TestOtherInterfaceType::class,
+                ],
+            ),
         );
     }
 
@@ -88,6 +104,17 @@ final class AstTest extends TestCase
     {
         self::assertSame($this->typeNode, $this->ast->getNodeByClassName(TestType::class));
         self::assertSame($this->enumNode2, $this->ast->getNodeByClassName(TestAnotherEnumType::class));
+    }
+
+    #[Test]
+    public function itShouldGetNodesImplementingAnInterface(): void
+    {
+        $nodes = $this->ast->getNodesImplementingInterface();
+
+        self::assertSame([
+            $this->typeNode,
+            $this->interfaceTypeNode,
+        ], $nodes);
     }
 
     #[Test]


### PR DESCRIPTION
# Description
Interface Types where already working on root level (Query, Mutation), but not inside other Types yet. This PR enables interface types (either real PHP interfaces or abstracts) when defined inside other Types.

See docs: https://github.com/jerowork/graphql-attribute-schema/blob/main/docs/usage.md#interfacetype