### PR TITLE
Fix: Allow null input values for InputType and enums

### DIFF
--- a/src/Resolver/Type/EnumTypeResolver.php
+++ b/src/Resolver/Type/EnumTypeResolver.php
@@ -102,12 +102,12 @@ final class EnumTypeResolver implements TypeResolver
             return array_map(fn($item) => $className::from($item), $value);
         }
 
-        if (!array_key_exists($node->name, $args)) {
+        /** @var null|string $value */
+        $value = $args[$node->name] ?? null;
+
+        if ($value === null) {
             return null;
         }
-
-        /** @var string $value */
-        $value = $args[$node->name];
 
         return $className::from($value);
     }

--- a/src/Resolver/Type/InputObjectTypeResolver.php
+++ b/src/Resolver/Type/InputObjectTypeResolver.php
@@ -83,12 +83,12 @@ final class InputObjectTypeResolver implements TypeResolver
             );
         }
 
-        if (!array_key_exists($node->name, $args)) {
+        /** @var null|array<string, mixed> $nodeArgs */
+        $nodeArgs = $args[$node->name] ?? null;
+
+        if ($nodeArgs === null) {
             return null;
         }
-
-        /** @var array<string, mixed> $nodeArgs */
-        $nodeArgs = $args[$node->name];
 
         return new $className(...array_map(
             fn($fieldNode) => $this->getTypeResolverSelector()

--- a/tests/Resolver/Type/EnumTypeResolverTest.php
+++ b/tests/Resolver/Type/EnumTypeResolverTest.php
@@ -175,7 +175,7 @@ final class EnumTypeResolverTest extends TestCase
     }
 
     #[Test]
-    public function itShouldAbstractNullable(): void
+    public function itShouldAbstractAbsentArgument(): void
     {
         $this->astContainer->setAst(new Ast(
             new EnumNode(
@@ -200,6 +200,38 @@ final class EnumTypeResolverTest extends TestCase
             null,
             null,
         ), []);
+
+        self::assertNull($enum);
+    }
+
+    #[Test]
+    public function itShouldAbstractNullArgument(): void
+    {
+        $this->astContainer->setAst(new Ast(
+            new EnumNode(
+                TestEnumType::class,
+                'enum',
+                'A description',
+                [
+                    new EnumValueNode('a', 'Value A', null),
+                    new EnumValueNode('b', null, 'Its deprecated'),
+                ],
+            ),
+        ));
+
+        $enum = $this->resolver->abstract(new FieldNode(
+            ObjectTypeReference::create(TestEnumType::class),
+            'enum',
+            null,
+            [],
+            FieldNodeType::Property,
+            null,
+            'enum',
+            null,
+            null,
+        ), [
+            'enum' => null,
+        ]);
 
         self::assertNull($enum);
     }

--- a/tests/Resolver/Type/InputObjectTypeResolverTest.php
+++ b/tests/Resolver/Type/InputObjectTypeResolverTest.php
@@ -201,4 +201,84 @@ final class InputObjectTypeResolverTest extends TestCase
 
         self::assertEquals(new TestSmallInputType('identifier'), $abstract);
     }
+
+    #[Test]
+    public function itShouldAbstractWithAbsentArgument(): void
+    {
+        $this->astContainer->setAst(new Ast(
+            new InputTypeNode(
+                TestSmallInputType::class,
+                'TestInput',
+                null,
+                [
+                    new FieldNode(
+                        ScalarTypeReference::create('string'),
+                        'id',
+                        null,
+                        [],
+                        FieldNodeType::Property,
+                        null,
+                        'id',
+                        null,
+                        null,
+                    ),
+                ],
+            ),
+        ));
+
+        $abstract = $this->resolver->abstract(new FieldNode(
+            ObjectTypeReference::create(TestSmallInputType::class),
+            'smallInput',
+            null,
+            [],
+            FieldNodeType::Property,
+            null,
+            'smallInput',
+            null,
+            null,
+        ), []);
+
+        self::assertNull($abstract);
+    }
+
+    #[Test]
+    public function itShouldAbstractWithNullArgument(): void
+    {
+        $this->astContainer->setAst(new Ast(
+            new InputTypeNode(
+                TestSmallInputType::class,
+                'TestInput',
+                null,
+                [
+                    new FieldNode(
+                        ScalarTypeReference::create('string'),
+                        'id',
+                        null,
+                        [],
+                        FieldNodeType::Property,
+                        null,
+                        'id',
+                        null,
+                        null,
+                    ),
+                ],
+            ),
+        ));
+
+        $abstract = $this->resolver->abstract(new FieldNode(
+            ObjectTypeReference::create(TestSmallInputType::class),
+            'smallInput',
+            null,
+            [],
+            FieldNodeType::Property,
+            null,
+            'smallInput',
+            null,
+            null,
+        ), [
+            'smallInput' => null,
+        ]);
+
+        self::assertNull($abstract);
+    }
 }


### PR DESCRIPTION
# Description
Sometimes, when dynamically generated, an input type sends a null value for a certain input type. When this happens, it should not try to create the input type object (as its null), but simply return null.

e.g.
```
mutation SomeMutation(someKey: {
  anotherKey: "value",
  nullableKey: null
}) {
  id
}
```