### PR TITLE
Index AST nodes by class name for O(1) getNodeByClassName lookups

### DIFF
--- a/src/Ast.php
+++ b/src/Ast.php
@@ -25,9 +25,35 @@ final readonly class Ast implements ArraySerializable
      */
     private array $nodes;
 
+    /**
+     * Index of nodes by class name, with aliases as a fallback, for O(1) lookups in getNodeByClassName().
+     *
+     * @var array<class-string, Node>
+     */
+    private array $nodesByName;
+
     public function __construct(Node ...$nodes)
     {
         $this->nodes = array_values($nodes);
+
+        // Index class names first so they take precedence over aliases.
+        $nodesByName = [];
+
+        foreach ($this->nodes as $node) {
+            $nodesByName[$node->getClassName()] ??= $node;
+        }
+
+        foreach ($this->nodes as $node) {
+            if ($node instanceof AliasedNode) {
+                $alias = $node->getAlias();
+
+                if ($alias !== null) {
+                    $nodesByName[$alias] ??= $node;
+                }
+            }
+        }
+
+        $this->nodesByName = $nodesByName;
     }
 
     /**
@@ -47,28 +73,7 @@ final readonly class Ast implements ArraySerializable
      */
     public function getNodeByClassName(string $className): ?Node
     {
-        foreach ($this->nodes as $node) {
-            if ($node->getClassName() !== $className) {
-                continue;
-            }
-
-            return $node;
-        }
-
-        // Try to retrieve node by alias
-        foreach ($this->nodes as $node) {
-            if (!$node instanceof AliasedNode) {
-                continue;
-            }
-
-            if ($node->getAlias() !== $className) {
-                continue;
-            }
-
-            return $node;
-        }
-
-        return null;
+        return $this->nodesByName[$className] ?? null;
     }
 
     /**

--- a/tests/AstTest.php
+++ b/tests/AstTest.php
@@ -12,6 +12,7 @@ use Jerowork\GraphqlAttributeSchema\Node\InputTypeNode;
 use Jerowork\GraphqlAttributeSchema\Node\InterfaceTypeNode;
 use Jerowork\GraphqlAttributeSchema\Node\MutationNode;
 use Jerowork\GraphqlAttributeSchema\Node\QueryNode;
+use Jerowork\GraphqlAttributeSchema\Node\ScalarNode;
 use Jerowork\GraphqlAttributeSchema\Node\TypeNode;
 use Jerowork\GraphqlAttributeSchema\Node\TypeReference\ObjectTypeReference;
 use Jerowork\GraphqlAttributeSchema\Node\TypeReference\ScalarTypeReference;
@@ -22,6 +23,7 @@ use Jerowork\GraphqlAttributeSchema\Test\Doubles\InterfaceType\TestInterfaceType
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\InterfaceType\TestOtherInterfaceType;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Mutation\TestMutation;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Query\TestQuery;
+use Jerowork\GraphqlAttributeSchema\Test\Doubles\Scalar\TestScalarType;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Type\Loader\TestTypeLoader;
 use Jerowork\GraphqlAttributeSchema\Test\Doubles\Type\TestType;
 use Override;
@@ -104,6 +106,46 @@ final class AstTest extends TestCase
     {
         self::assertSame($this->typeNode, $this->ast->getNodeByClassName(TestType::class));
         self::assertSame($this->enumNode2, $this->ast->getNodeByClassName(TestAnotherEnumType::class));
+        self::assertNull($this->ast->getNodeByClassName(TestQuery::class));
+    }
+
+    #[Test]
+    public function itShouldGetNodeByAliasWhenThereIsNoClassNameMatch(): void
+    {
+        $ast = new Ast(
+            $scalarNode = new ScalarNode(
+                TestScalarType::class,
+                'TestScalar',
+                null,
+                TestAnotherEnumType::class,
+            ),
+        );
+
+        self::assertSame($scalarNode, $ast->getNodeByClassName(TestScalarType::class));
+        self::assertSame($scalarNode, $ast->getNodeByClassName(TestAnotherEnumType::class));
+    }
+
+    #[Test]
+    public function itShouldPreferAClassNameMatchOverAnAliasMatch(): void
+    {
+        $ast = new Ast(
+            new ScalarNode(
+                TestScalarType::class,
+                'TestScalar',
+                null,
+                TestType::class,
+            ),
+            $typeNode = new TypeNode(
+                TestType::class,
+                'type',
+                null,
+                [],
+                null,
+                [],
+            ),
+        );
+
+        self::assertSame($typeNode, $ast->getNodeByClassName(TestType::class));
     }
 
     #[Test]


### PR DESCRIPTION
## Why

`Ast::getNodeByClassName()` performs two linear scans over **every** node on each call (first matching by class name, then by alias). The schema builder and type resolvers call it once for every referenced type while resolving fields — and `BuiltTypesRegistryTypeResolverDecorator::createType()` calls it on *every* reference even when the built type is already cached, just to compute the cache key. On a non-trivial schema this becomes a hot path.

Profiling a production GraphQL service built on this library (253 attribute-defined types) with SPX, a single request triggered **~3,300 `getNodeByClassName()` calls** (hundreds of thousands of `getClassName()` comparisons), and that method dominated the request's inclusive wall time. Because the schema is rebuilt/resolved per request (PHP-FPM, no long-lived worker), the cost is paid on every request.

End-to-end, on that service's real schema (fresh kernel boot + handle per request, opcache warm, `APP_ENV=prod`):

| | per request |
|---|---|
| before (linear scan) | ~65 ms |
| after (this PR) | ~19.6 ms |

i.e. ~45 ms / ~70% off the request, with the remainder being framework boot rather than schema resolution.

## What

Build a class-name index and an alias index **once** in the constructor (the `Ast` is immutable / `readonly`) and resolve `getNodeByClassName()` from them in O(1). The existing **class-name-before-alias** resolution order and first-match-wins semantics are preserved (`??=`).

## Tests

- Added `AstTest` cases for the alias-fallback path, class-name-priority-over-alias, and the not-found case (the previous suite only covered class-name matches).
- Full suite green locally: `phpunit` (177 tests), `rector`, `php-cs-fixer`, `composer-dependency-analyser`. No new PHPStan findings introduced by this change.
