### PR TITLE
Add .gitattributes to slim distribution archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ignore everything by default
+* export-ignore
+
+# Include only these in distribution
+src/ -export-ignore
+src/** -export-ignore
+composer.json -export-ignore
+LICENSE -export-ignore


### PR DESCRIPTION
Composer dist installs use the GitHub-generated archive, which otherwise ships tests, CI config, and tooling that consumers never need. Ignore everything by default and re-include only the runtime essentials (`src/`, `composer.json`, `LICENSE`) so dependents pull the smallest possible package.